### PR TITLE
[Spree 2.4] Touch products when relation gets created/updated

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,24 @@
 language: ruby
+dist: trusty
+cache:
+  bundler: true
+  directories:
+    - "travis_phantomjs"
 rvm:
   - 1.9.3
   - 2.0.0
   - 2.1.0
 sudo: false
+before_install:
+  - "phantomjs --version"
+  - "export PATH=$PWD/travis_phantomjs/phantomjs-2.1.1-linux-x86_64/bin:$PATH"
+  - "phantomjs --version"
+  - "if [ $(phantomjs --version) != '2.1.1' ]; then rm -rf $PWD/travis_phantomjs; mkdir -p $PWD/travis_phantomjs; fi"
+  - "if [ $(phantomjs --version) != '2.1.1' ]; then wget https://assets.membergetmember.co/software/phantomjs-2.1.1-linux-x86_64.tar.bz2 -O $PWD/travis_phantomjs/phantomjs-2.1.1-linux-x86_64.tar.bz2; fi"
+  - "if [ $(phantomjs --version) != '2.1.1' ]; then tar -xvf $PWD/travis_phantomjs/phantomjs-2.1.1-linux-x86_64.tar.bz2 -C $PWD/travis_phantomjs; fi"
+  - "phantomjs --version"
+  - gem install bundler
 before_script:
-  - sh -e /etc/init.d/xvfb start
-  - export DISPLAY=:99.0
   - bundle exec rake test_app
 script:
   - bundle exec rspec spec

--- a/app/models/spree/relation.rb
+++ b/app/models/spree/relation.rb
@@ -1,7 +1,7 @@
 class Spree::Relation < ActiveRecord::Base
   belongs_to :relation_type
-  belongs_to :relatable, polymorphic: true
-  belongs_to :related_to, polymorphic: true
+  belongs_to :relatable, polymorphic: true, touch: true
+  belongs_to :related_to, polymorphic: true, touch: true
 
   validates :relation_type, :relatable, :related_to, presence: true
 end

--- a/spec/models/spree/relation_spec.rb
+++ b/spec/models/spree/relation_spec.rb
@@ -12,4 +12,20 @@ describe Spree::Relation do
     it { should validate_presence_of(:relatable) }
     it { should validate_presence_of(:related_to) }
   end
+
+  describe 'after create' do
+    let!(:product) { create(:product) }
+    let!(:related_product) { create(:product) }
+
+    it 'touches the products', :aggregate_failures do
+      expect(product).to receive(:touch)
+      expect(related_product).to receive(:touch)
+
+      Spree::Relation.create!(
+        relation_type: create(:relation_type),
+        relatable: product,
+        related_to: related_product
+      )
+    end
+  end
 end


### PR DESCRIPTION
When a product gets related to another product the cache key doesn't get
updated. This fixes this by enabling touch option the belongs_to
associations.